### PR TITLE
Set `extensionKind` to `ui`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "onLanguage:tsv"
     ],
     "main": "./dist/extension.js",
+    "extensionKind": [ "ui" ],
     "contributes": {
         "commands": [
             {


### PR DESCRIPTION
Set `extensionKind` to `ui` to prevent from being installed on server when editing remotely.